### PR TITLE
Fix #2 Rename parquetgo -> parquet-go

### DIFF
--- a/columnifier/parquet.go
+++ b/columnifier/parquet.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/reproio/columnify/record"
 
-	"github.com/reproio/columnify/parquet-go"
+	"github.com/reproio/columnify/parquet"
 	"github.com/reproio/columnify/schema"
 	"github.com/xitongsys/parquet-go-source/local"
 	parquetSource "github.com/xitongsys/parquet-go/source"
@@ -41,7 +41,7 @@ func NewParquetColumnifier(st string, sf string, rt string, output string) (*par
 			return nil, err
 		}
 	} else {
-		fw = parquet_go.NewStdioFile()
+		fw = parquet.NewStdioFile()
 	}
 
 	w, err := writer.NewParquetWriter(fw, nil, 1)
@@ -60,7 +60,7 @@ func NewParquetColumnifier(st string, sf string, rt string, output string) (*par
 
 func (c *parquetColumnifier) Write(data []byte) error {
 	// Intermediate record type is map[string]interface{}
-	c.w.MarshalFunc = parquet_go.MarshalMap
+	c.w.MarshalFunc = parquet.MarshalMap
 	records, err := record.FormatToMap(data, c.schema, c.rt)
 	if err != nil {
 		return err

--- a/parquet/doc.go
+++ b/parquet/doc.go
@@ -9,4 +9,4 @@
 	parquetgo package enriches these points for handling Arrow based data.
 
 */
-package parquet_go
+package parquet

--- a/parquet/marshal_arrow.go
+++ b/parquet/marshal_arrow.go
@@ -1,4 +1,4 @@
-package parquet_go
+package parquet
 
 import (
 	"fmt"

--- a/parquet/marshal_arrow_test.go
+++ b/parquet/marshal_arrow_test.go
@@ -1,4 +1,4 @@
-package parquet_go
+package parquet
 
 import (
 	"fmt"

--- a/parquet/marshal_map.go
+++ b/parquet/marshal_map.go
@@ -1,4 +1,4 @@
-package parquet_go
+package parquet
 
 import (
 	"bytes"

--- a/parquet/marshal_map_test.go
+++ b/parquet/marshal_map_test.go
@@ -1,4 +1,4 @@
-package parquet_go
+package parquet
 
 import (
 	"bytes"

--- a/parquet/stdio.go
+++ b/parquet/stdio.go
@@ -1,4 +1,4 @@
-package parquet_go
+package parquet
 
 import (
 	"fmt"

--- a/parquet/table.go
+++ b/parquet/table.go
@@ -1,4 +1,4 @@
-package parquet_go
+package parquet
 
 import (
 	"fmt"


### PR DESCRIPTION
https://github.com/reproio/columnify/issues/2

`parquet-go` is better to indicate what's that package.