### PR TITLE
Fix #1 Implement io.WriterCloser

### DIFF
--- a/cmd/columnify/columnify.go
+++ b/cmd/columnify/columnify.go
@@ -44,9 +44,4 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to write: %v\n", err)
 	}
-
-	err = c.Finalize()
-	if err != nil {
-		log.Fatalf("Failed to finalize: %v\n", err)
-	}
 }

--- a/columnifier/columnifier.go
+++ b/columnifier/columnifier.go
@@ -16,7 +16,6 @@ type Columnifier interface {
 	io.WriteCloser
 
 	WriteFromFiles(paths []string) (int, error)
-	Finalize() error
 }
 
 func NewColumnifier(st string, sf string, rt string, o string) (Columnifier, error) {

--- a/columnifier/parquet.go
+++ b/columnifier/parquet.go
@@ -107,22 +107,9 @@ func (c *parquetColumnifier) WriteFromFiles(paths []string) (int, error) {
 	return n, nil
 }
 
-// Finalize flushes buffers and finalize creating a parquet file.
-func (c *parquetColumnifier) Finalize() error {
+func (c *parquetColumnifier) Close() error {
 	if err := c.w.WriteStop(); err != nil {
 		return err
-	}
-	c.finalized = true
-
-	return nil
-}
-
-func (c *parquetColumnifier) Close() error {
-	if !c.finalized {
-		err := c.Finalize()
-		if err != nil {
-			return err
-		}
 	}
 
 	return c.w.PFile.Close()


### PR DESCRIPTION
Change/add signatures to implement `io.WriterCloser` to suit similar use cases.

https://github.com/reproio/columnify/issues/1