### PR TITLE
Ignore executable built by go build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Executable
+/columnify
+
 # Binaries for programs and plugins
 *.exe
 *.exe~


### PR DESCRIPTION
This PR will add an entry to .gitignore to ignore executable `columnify` generated by `make build`.