### PR TITLE
Update Apache Arrow to adopt Go 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	cloud.google.com/go/bigquery v1.4.0
 	github.com/Songmu/go-ltsv v0.0.0-20181014062614-c30af2b7b171
-	github.com/apache/arrow/go/arrow v0.0.0-20200227150411-3d81e4e76945
+	github.com/apache/arrow/go/arrow v0.0.0-20200504153628-d13e8f3ed647
 	github.com/linkedin/goavro/v2 v2.9.7
 	github.com/vmihailenco/msgpack/v4 v4.3.11
 	github.com/xitongsys/parquet-go v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Songmu/go-ltsv v0.0.0-20181014062614-c30af2b7b171 h1:nwdeQV2pNjaTv3os4N4/bKDqv0PxW/9DoEAdtW6sY9o=
 github.com/Songmu/go-ltsv v0.0.0-20181014062614-c30af2b7b171/go.mod h1:LBP+tS9C2iiUoR7AGPaZYY+kjXgB5eZxZKbSEBL9UFw=
-github.com/apache/arrow/go/arrow v0.0.0-20200227150411-3d81e4e76945 h1:36H+D+KuuYzz59uwF9qElOGWtsbFkIw9LvyzRX4aLvU=
-github.com/apache/arrow/go/arrow v0.0.0-20200227150411-3d81e4e76945/go.mod h1:QNYViu/X0HXDHw7m3KXzWSVXIbfUvJqBFe6Gj8/pYA0=
+github.com/apache/arrow/go/arrow v0.0.0-20200504153628-d13e8f3ed647 h1:wGcHSHIBp0+NEMyXG2N0878wAl5J3yOFDU5RZECDSj8=
+github.com/apache/arrow/go/arrow v0.0.0-20200504153628-d13e8f3ed647/go.mod h1:QNYViu/X0HXDHw7m3KXzWSVXIbfUvJqBFe6Gj8/pYA0=
 github.com/apache/thrift v0.0.0-20181112125854-24918abba929 h1:ubPe2yRkS6A/X37s0TVGfuN42NV2h0BlzWj0X76RoUw=
 github.com/apache/thrift v0.0.0-20181112125854-24918abba929/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
ref. https://issues.apache.org/jira/browse/ARROW-8098

It causes a failure on go-test
```
 $ make test
go test -race -cover ./...
ok      github.com/reproio/columnify/avro       (cached)        coverage: 87.3% of statements
?       github.com/reproio/columnify/cmd/columnify      [no test files]
ok      github.com/reproio/columnify/columnifier        (cached)        coverage: 8.0% of statements
fatal error: checkptr: unsafe pointer arithmetic

goroutine 51 [running]:
runtime.throw(0x1a2fb8e, 0x23)
        /usr/local/opt/go/libexec/src/runtime/panic.go:1116 +0x72 fp=0xc0000b0a68 sp=0xc0000b0a38 pc=0x1073ed2
runtime.checkptrArithmetic(0x40, 0x0, 0x0, 0x0)
        /usr/local/opt/go/libexec/src/runtime/checkptr.go:26 +0xce fp=0xc0000b0a98 sp=0xc0000b0a68 pc=0x1045e1e
github.com/apache/arrow/go/arrow/memory.memory_memset_avx2(0xc000148100, 0x40, 0x40, 0xc00010e400)
        /Users/ryo/.go/pkg/mod/github.com/apache/arrow/go/arrow@v0.0.0-20200227150411-3d81e4e76945/memory/memory_avx2_amd64.go:33 +0x5c fp=0xc0000b0ad8 sp=0xc0
000b0a98 pc=0x126108c
github.com/apache/arrow/go/arrow/memory.Set(...)
        /Users/ryo/.go/pkg/mod/github.com/apache/arrow/go/arrow@v0.0.0-20200227150411-3d81e4e76945/memory/memory.go:25
github.com/apache/arrow/go/arrow/array.(*builder).init(0xc000098480, 0x20)
        /Users/ryo/.go/pkg/mod/github.com/apache/arrow/go/arrow@v0.0.0-20200227150411-3d81e4e76945/array/builder.go:101 +0x23a fp=0xc0000b0b50 sp=0xc0000b0ad8
pc=0x126d84a
github.com/apache/arrow/go/arrow/array.(*BooleanBuilder).init(0xc000098480, 0x20)
        /Users/ryo/.go/pkg/mod/github.com/apache/arrow/go/arrow@v0.0.0-20200227150411-3d81e4e76945/array/booleanbuilder.go:100 +0x4c fp=0xc0000b0bc8 sp=0xc0000
b0b50 pc=0x126b32c
github.com/apache/arrow/go/arrow/array.(*BooleanBuilder).Resize(0xc000098480, 0x4)
        /Users/ryo/.go/pkg/mod/github.com/apache/arrow/go/arrow@v0.0.0-20200227150411-3d81e4e76945/array/booleanbuilder.go:122 +0x6f fp=0xc0000b0c38 sp=0xc0000
b0bc8 pc=0x126b6af
github.com/apache/arrow/go/arrow/array.(*BooleanBuilder).Resize-fm(0x4)
        /Users/ryo/.go/pkg/mod/github.com/apache/arrow/go/arrow@v0.0.0-20200227150411-3d81e4e76945/array/booleanbuilder.go:116 +0x4c fp=0xc0000b0c60 sp=0xc0000
b0c38 pc=0x12aa94c
github.com/apache/arrow/go/arrow/array.(*builder).reserve(0xc000098480, 0x2, 0xc0000b0ca0)
        /Users/ryo/.go/pkg/mod/github.com/apache/arrow/go/arrow@v0.0.0-20200227150411-3d81e4e76945/array/builder.go:138 +0xdc fp=0xc0000b0c88 sp=0xc0000b0c60 p
c=0x126de0c
github.com/apache/arrow/go/arrow/array.(*BooleanBuilder).Reserve(0xc000098480, 0x2)
        /Users/ryo/.go/pkg/mod/github.com/apache/arrow/go/arrow@v0.0.0-20200227150411-3d81e4e76945/array/booleanbuilder.go:111 +0x68 fp=0xc0000b0cc0 sp=0xc0000
b0c88 pc=0x126b628
github.com/apache/arrow/go/arrow/array.(*BooleanBuilder).AppendValues(0xc000098480, 0xc0000b0d76, 0x2, 0x2, 0xc0000b0d74, 0x2, 0x2)
        /Users/ryo/.go/pkg/mod/github.com/apache/arrow/go/arrow@v0.0.0-20200227150411-3d81e4e76945/array/booleanbuilder.go:92 +0x69 fp=0xc0000b0d38 sp=0xc0000b
0cc0 pc=0x126b069
github.com/reproio/columnify/parquet.TestNewArrowSchemaFromAvroSchema.func1(0xc00013c080, 0x1a1fdcc, 0xa, 0xc000180000)
        /Users/ryo/.go/src/github.com/reproio/columnify/parquet/marshal_arrow_test.go:29 +0x14b fp=0xc0000b0e80 sp=0xc0000b0d38 pc=0x18cde7b
...
```

NOTE: The tagging on Apache Arrow repo doesn't follow semver, like `v1.2.3` so the selected version looks something wrong ...