### PR TITLE
Fix example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ cat examples/record/primitives.jsonl
 {"boolean": false, "int": 1, "long": 1, "float": 1.1, "double": 1.1, "bytes": "foo", "string": "foo"}
 {"boolean": true, "int": 2, "long": 2, "float": 2.2, "double": 2.2, "bytes": "bar", "string": "bar"}
 
-$ ./columnify -schemaType avro -schemaFile examples/avro/primitives.avsc -recordType jsonl examples/avro/primitives.jsonl > out.parquet
+$ ./columnify -schemaType avro -schemaFile examples/schema/primitives.avsc -recordType jsonl examples/record/primitives.jsonl > out.parquet
 
 $ parquet-tools schema out.parquet
 message Primitives {


### PR DESCRIPTION
I found the example section on README has wrong file paths.