### PR TITLE
Fix #48 Publish coverfile to codecov

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,3 +43,8 @@ jobs:
 
     - name: Integration test
       run: make it
+
+    - uses: codecov/codecov-action@v1
+      with:
+        file: ./cover.out
+        flags: unittests

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ fmt:
 # ref. https://github.com/xitongsys/parquet-go/issues/256
 .PHONY: test
 test:
-	go test -cover ./...
+	go test -cover -coverprofile=cover.out ./...
 
 .PHONY: it
 it: build

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![Go](https://github.com/reproio/columnify/workflows/Go/badge.svg)
 ![goreleaser](https://github.com/reproio/columnify/workflows/goreleaser/badge.svg)
+[![codecov](https://codecov.io/gh/reproio/columnify/branch/master/graph/badge.svg)](https://codecov.io/gh/reproio/columnify)
 
 Make record oriented data to columnar format.
 


### PR DESCRIPTION
https://github.com/reproio/columnify/issues/48, to visualize code coverage.