### PR TITLE
Change GO111MODULE=on to be able to install with go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Columnar formatted data is efficient for analytics queries, lightweight and ease
 ### Installation
 
 ```sh
-$ GO111MODULE=off go get github.com/reproio/columnify/cmd/columnify
+$ GO111MODULE=on go get github.com/reproio/columnify/cmd/columnify
 ```
 
 ### Usage


### PR DESCRIPTION
# Description

## Why

I couldn't install columnify with `GO111MODULE=off go get`. Fix #55.

```
$ GO111MODULE=off go get github.com/reproio/columnify/cmd/columnify
package github.com/vmihailenco/msgpack/v4: cannot find package "github.com/vmihailenco/msgpack/v4" in any of:
	/usr/lib/go-1.14/src/github.com/vmihailenco/msgpack/v4 (from $GOROOT)
	path/to/tmp/src/github.com/vmihailenco/msgpack/v4 (from $GOPATH)
```

## What

> This project uses Go Modules and semantic import versioning since v4:

According to the description in https://github.com/vmihailenco/msgpack , `vmihailenco/msgpack` uses Go Modules and semantic import versioning. To use Go Modules with `$GOPATH` (or go get?), we have to set `GO111MODULE=on` explicitly.

## Concern

@syucream I'm not sure why original README describes `GO111MODULE=off` to install. Tell me if my understanding is wrong about installing columnify with go get.

# Reference

* https://github.com/golang/go/wiki/Modules
* https://dev.to/maelvls/why-is-go111module-everywhere-and-everything-about-go-modules-24k