### PR TITLE
Add tips about memory usage and GOGC environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ $ parquet-tools cat -json out.parquet
   - An example is `examples/fluent-plugin-s3`
   - It works as a Compressor of fluent-plugin-s3 write parquet file to tmp via chunk data.
 
+## Additional tips
+
+### Set GOGC to reduce memory usage
+
+`columnify` might consume lots of memory usage depends on a value by `-parquetRowGroupSize`. At least, it needs memory usage of row group size. Actually, it consumes more than double row group size by default. The reason why is depending on Go's garbage collection behavior. To trigger GC frequently, set `GOGC` environment variable.
+
+> SetGCPercent sets the garbage collection target percentage: a collection is triggered when the ratio of freshly allocated data to live data remaining after the previous collection reaches this percentage. SetGCPercent returns the previous setting. The initial setting is the value of the GOGC environment variable at startup, or 100 if the variable is not set. A negative percentage disables garbage collection.
+>
+> https://golang.org/pkg/runtime/debug/#SetGCPercent
+
+Of course, frequent GC makes it increase execution time. Confirm which GOGC value (percent) is better in your environment.
+
 ## Limilations
 
 Currently it has some limitations from schema/record types.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ $ parquet-tools cat -json out.parquet
 
 ### Set GOGC to reduce memory usage
 
-`columnify` might consume lots of memory usage depends on a value by `-parquetRowGroupSize`. At least, it needs memory usage of row group size. Actually, it consumes more than double row group size by default. The reason why is depending on Go's garbage collection behavior. To trigger GC frequently, set `GOGC` environment variable.
+`columnify` might consume lots of memory depending on a value specified by `-parquetRowGroupSize`. At least, it needs a memory of the row group size. Actually, it consumes more than double the row group size by default. The reason for that depends on Go's garbage collection behavior, and memory usage can decrease by triggering GC frequently. To adjust the frequency, set `GOGC` environment variable.
 
 > SetGCPercent sets the garbage collection target percentage: a collection is triggered when the ratio of freshly allocated data to live data remaining after the previous collection reaches this percentage. SetGCPercent returns the previous setting. The initial setting is the value of the GOGC environment variable at startup, or 100 if the variable is not set. A negative percentage disables garbage collection.
 >


### PR DESCRIPTION
In my environment, `columnify` consume memory usage more than double row group size. I confirmed the memory usage by time command.

I created test data from https://github.com/abicky/docker-log-and-fluent-plugin-s3-with-columnify-example. The value of `-parquetRowGroupSize` is 128MiB.

```bash
$ /usr/bin/time -v path/to/columnify \
  -parquetCompressionCodec SNAPPY \
  -parquetPageSize 8192 \
  -parquetRowGroupSize 134217728 \
  -recordType msgpack \
  -schemaType avro \
  -schemaFile fluentd/docker_log.avsc \
  -output /tmp/2020082412_0.parquet 
  2020082412_0.msgpack
```

By default, this command outputs below.

```
User time (seconds): 13.31
System time (seconds): 0.42
Percent of CPU this job got: 125%
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:10.90
Maximum resident set size (kbytes): 291528
```

Set `GOGC=50`, and the result is below.

```bash
$ export GOGC=50
$ /usr/bin/time -v path/to/columnify \
...
User time (seconds): 15.96
System time (seconds): 0.50
Percent of CPU this job got: 141%
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:11.59
Maximum resident set size (kbytes): 229504
```

Set `GOGC=10`, and the result is below.

```bash
$ export GOGC=10
$ /usr/bin/time -v path/to/columnify \
...
User time (seconds): 30.15
System time (seconds): 0.50
Percent of CPU this job got: 232%
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:13.19
Maximum resident set size (kbytes): 174136
```

`GOGC` parameter is useful when we want to reduce the Maximum resident set size. Could you confirm whether my thinking is valid or not in your environment?